### PR TITLE
Add error handling for the export method in Main.java 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cooking Project
-We're developing a command line tool in Java to help you plan meals. To accomplish this, we're using the [WebKnox Recipe API](http://webknox.com/api#!/recipes/getRandomPopularRecipes_GET). Updated ReadMe for Iteration 2 is in Dev Branch.
+We're developing a command line tool in Java to help you plan meals. To accomplish this, we're using the [WebKnox Recipe API](http://webknox.com/api#!/recipes/getRandomPopularRecipes_GET)
 
 ## Iteration 2
 * User stories completed this iteration:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cooking Project
-We're developing a command line tool in Java to help you plan meals. To accomplish this, we're using the [WebKnox Recipe API](http://webknox.com/api#!/recipes/getRandomPopularRecipes_GET)
+We're developing a command line tool in Java to help you plan meals. To accomplish this, we're using the [WebKnox Recipe API](http://webknox.com/api#!/recipes/getRandomPopularRecipes_GET). Updated ReadMe for Iteration 2 is in Dev Branch.
 
 ## Iteration 1
 * User stories completed this iteration: 

--- a/src/main/Main.java
+++ b/src/main/Main.java
@@ -13,7 +13,21 @@ public class Main {
 		String response = controller.initialize();
 		if (response.equals("1")) {
 			String text = aPIController.getRandomPopularRecipe();
-			exporter.export(text);
+			switch (exporter.export(text)) 
+			{
+				case success:
+					System.out.println("...and we got it! You'll find it in the recipes folder :)");
+					break;
+				case parse_failure:
+				case missing_fields_failure:
+					System.out.println("...but there was an issue with it, so we weren't able to grab it for you. Sorry about that :(");
+					break;
+				case file_creation_failure:
+					System.out.println("...but we had trouble making a new file for it, so it was lost. Sorry about that :(");
+				default:
+					System.out.println("...but we ran into some trouble, so it was lost. Sorry about that :(");
+					break;
+			}
 			controller.continuePrompt();
 		}
 	}


### PR DESCRIPTION
This is a minor commit that makes use of the enum functionality in Exporter.export(). Additionally, it makes the UX more consistent by providing a concluding statement for the trailing ellipsis left by the message in Exporter.export().